### PR TITLE
chore: update base image and only install production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-alpine AS build-stage
+FROM node:16.17.1-alpine AS build-stage
 
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
@@ -8,7 +8,7 @@ COPY package*.json ./
 
 USER node
 
-RUN npm ci --loglevel error --no-fund
+RUN npm ci --loglevel error --no-fund --only-production
 
 COPY --chown=node:node . .
 


### PR DESCRIPTION
## Description

update the base image and only install the production

## Motivation and Context

Making image smaller and more secure
