### PR TITLE
chore: depandabot ignore oidc-provider upgrade for version 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "oidc-provider"
+        versions: ["8.x"]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^4.17.21",
     "nanoid": "^3.1.28",
     "oauth2-server": "^3.1.1",
-    "oidc-provider": "7.10.6",
+    "oidc-provider": "^7.10.6",
     "pg": "^8.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

added depandabot upgrade ignore config for oidc-provider version 8.x

## Motivation and Context

oidc-provider version 8.x is not compatible 

